### PR TITLE
Add microk8s provider

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -55,6 +55,14 @@ function run() {
                 yield exec.exec("sudo snap install juju --classic");
                 yield exec.exec("juju bootstrap localhost/localhost");
             }
+            else if (provider === "microk8s") {
+                yield exec.exec("sudo snap install microk8s --classic");
+                yield exec.exec("sudo snap install juju --classic");
+                yield exec.exec('bash', ['-c', 'sudo usermod -a -G microk8s $USER']);
+                yield exec.exec('sg microk8s -c "microk8s status --wait-ready"');
+                yield exec.exec('sg microk8s -c "microk8s enable storage dns"');
+                yield exec.exec('sg microk8s -c "juju bootstrap microk8s micro"');
+            }
             else {
                 core.setFailed(`Unknown provider: ${provider}`);
             }

--- a/lib/index.js
+++ b/lib/index.js
@@ -47,6 +47,14 @@ function run() {
                 yield exec.exec("sudo snap install juju --classic");
                 yield exec.exec("juju bootstrap localhost/localhost");
             }
+            else if (provider === "microk8s") {
+                yield exec.exec("sudo snap install microk8s --classic");
+                yield exec.exec("sudo snap install juju --classic");
+                yield exec.exec('bash', ['-c', 'sudo usermod -a -G microk8s $USER']);
+                yield exec.exec('sg microk8s -c "microk8s status --wait-ready"');
+                yield exec.exec('sg microk8s -c "microk8s enable storage dns"');
+                yield exec.exec('sg microk8s -c "juju bootstrap microk8s micro"');
+            }
             else {
                 core.setFailed(`Unknown provider: ${provider}`);
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,13 @@ async function run() {
             await exec.exec("lxc network set lxdbr0 ipv6.address none");
             await exec.exec("sudo snap install juju --classic");
             await exec.exec("juju bootstrap localhost/localhost");
+	} else if (provider === "microk8s") { 
+	    await exec.exec("sudo snap install microk8s --classic")
+	    await exec.exec("sudo snap install juju --classic")
+	    await exec.exec('bash', ['-c', 'sudo usermod -a -G microk8s $USER'])
+	    await exec.exec('sg microk8s -c "microk8s status --wait-ready"')
+	    await exec.exec('sg microk8s -c "microk8s enable storage dns"')
+	    await exec.exec('sg microk8s -c "juju bootstrap microk8s micro"')
         } else {
             core.setFailed(`Unknown provider: ${provider}`);
         }


### PR DESCRIPTION
Add's a provider for microk8s, tested during development of https://github.com/charmed-kubernetes/pytest-operator-template/tree/k8s

