### PR TITLE
Install charm and charmcraft snaps

### DIFF
--- a/dist/bootstrap/index.js
+++ b/dist/bootstrap/index.js
@@ -1635,6 +1635,14 @@ function run() {
                 core.setFailed(`Custom provider set without credentials: ${provider}`);
                 return;
             }
+            yield exec.exec("sudo snap install charm --classic");
+            yield exec.exec("sudo snap install charmcraft");
+            // Workaround for strictly confined charmcraft not being able to access /etc/gitconfig.
+            // (Also, self-hosted runners might not have /etc/gitconfig, so this has to ignore errors.)
+            const options = {};
+            options.ignoreReturnCode = true;
+            yield exec.exec("cat /etc/gitconfig >> $HOME/.gitconfig", [], options);
+            yield exec.exec("sudo rm /etc/gitconfig", [], options);
             yield exec.exec(bootstrap_command);
             core.exportVariable('CONTROLLER_NAME', controller_name);
         }

--- a/dist/bootstrap/index.js
+++ b/dist/bootstrap/index.js
@@ -1641,7 +1641,7 @@ function run() {
             // (Also, self-hosted runners might not have /etc/gitconfig, so this has to ignore errors.)
             const options = {};
             options.ignoreReturnCode = true;
-            yield exec.exec("cat /etc/gitconfig >> $HOME/.gitconfig", [], options);
+            yield exec.exec("bash", ["-c", `cat /etc/gitconfig >> ${HOME}/.gitconfig`], options);
             yield exec.exec("sudo rm /etc/gitconfig", [], options);
             yield exec.exec(bootstrap_command);
             core.exportVariable('CONTROLLER_NAME', controller_name);

--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -66,7 +66,7 @@ async function run() {
         // (Also, self-hosted runners might not have /etc/gitconfig, so this has to ignore errors.)
         const options: exec.ExecOptions = {}
         options.ignoreReturnCode = true;
-        await exec.exec("cat /etc/gitconfig >> $HOME/.gitconfig", [], options);
+        await exec.exec("bash", ["-c", `cat /etc/gitconfig >> ${HOME}/.gitconfig`], options);
         await exec.exec("sudo rm /etc/gitconfig", [], options);
 
         await exec.exec(bootstrap_command);

--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -59,6 +59,16 @@ async function run() {
             return
         }
 
+        await exec.exec("sudo snap install charm --classic");
+        await exec.exec("sudo snap install charmcraft");
+
+        // Workaround for strictly confined charmcraft not being able to access /etc/gitconfig.
+        // (Also, self-hosted runners might not have /etc/gitconfig, so this has to ignore errors.)
+        const options: exec.ExecOptions = {}
+        options.ignoreReturnCode = true;
+        await exec.exec("cat /etc/gitconfig >> $HOME/.gitconfig", [], options);
+        await exec.exec("sudo rm /etc/gitconfig", [], options);
+
         await exec.exec(bootstrap_command);
         core.exportVariable('CONTROLLER_NAME', controller_name);
     } catch(error) {


### PR DESCRIPTION
Due to charmed-kubernetes/pytest-operator#13 we need to switch to using the snaps for building charms, and this needs to ensure that those snaps are available. Additionally, the strict confinement of the `charmcraft` snap combined with the fact that the runners provided by GitHub automatically include `git-lfs` means that we have to work around the /etc/gitconfig access issue.

Fixes #8