### PR TITLE
Fix charmcraft install for classic confinement

### DIFF
--- a/dist/bootstrap/index.js
+++ b/dist/bootstrap/index.js
@@ -1660,13 +1660,7 @@ function run() {
                 return;
             }
             yield exec.exec("sudo snap install charm --classic");
-            yield exec.exec("sudo snap install charmcraft");
-            // Workaround for strictly confined charmcraft not being able to access /etc/gitconfig.
-            // (Also, self-hosted runners might not have /etc/gitconfig, so this has to ignore errors.)
-            const options = {};
-            options.ignoreReturnCode = true;
-            yield exec.exec("bash", ["-c", `cat /etc/gitconfig >> ${HOME}/.gitconfig`], options);
-            yield exec.exec("sudo rm /etc/gitconfig", [], options);
+            yield exec.exec("sudo snap install charmcraft --classic");
             yield exec.exec(bootstrap_command);
             core.exportVariable('CONTROLLER_NAME', controller_name);
         }

--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -83,14 +83,7 @@ async function run() {
         }
 
         await exec.exec("sudo snap install charm --classic");
-        await exec.exec("sudo snap install charmcraft");
-
-        // Workaround for strictly confined charmcraft not being able to access /etc/gitconfig.
-        // (Also, self-hosted runners might not have /etc/gitconfig, so this has to ignore errors.)
-        const options: exec.ExecOptions = {}
-        options.ignoreReturnCode = true;
-        await exec.exec("bash", ["-c", `cat /etc/gitconfig >> ${HOME}/.gitconfig`], options);
-        await exec.exec("sudo rm /etc/gitconfig", [], options);
+        await exec.exec("sudo snap install charmcraft --classic");
 
         await exec.exec(bootstrap_command);
         core.exportVariable('CONTROLLER_NAME', controller_name);


### PR DESCRIPTION
The charmcraft snap now uses classic confinement, so that flag needs to be given when performing the install. It also removes the need for the `/etc/gitconfig` handling, since charmcraft can read that directly now.