### PR TITLE
Install juju-bundle and kubectl

### DIFF
--- a/dist/bootstrap/index.js
+++ b/dist/bootstrap/index.js
@@ -1658,6 +1658,7 @@ function run() {
             yield exec.exec("sudo snap install jq");
             yield exec.exec("sudo snap install charm --classic");
             yield exec.exec("sudo snap install charmcraft --classic");
+            yield exec.exec("sudo snap install juju-bundle --classic");
             core.endGroup();
             let bootstrap_command = `juju bootstrap --debug --verbose ${provider} ${bootstrap_options}`;
             if (provider === "lxd") {
@@ -1746,6 +1747,14 @@ function run() {
                 core.endGroup();
             }
             core.exportVariable('CONTROLLER_NAME', controller_name);
+            core.startGroup("Install kubectl");
+            if (provider === "microk8s") {
+                yield exec.exec("sudo snap alias microk8s.kubectl kubectl");
+            }
+            else {
+                yield exec.exec("sudo snap install kubectl --classic");
+            }
+            core.endGroup();
         }
         catch (error) {
             core.setFailed(error.message);

--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -83,6 +83,7 @@ async function run() {
         await exec.exec("sudo snap install jq");
         await exec.exec("sudo snap install charm --classic");
         await exec.exec("sudo snap install charmcraft --classic");
+        await exec.exec("sudo snap install juju-bundle --classic");
         core.endGroup();
         let bootstrap_command = `juju bootstrap --debug --verbose ${provider} ${bootstrap_options}`
         if (provider === "lxd") {
@@ -165,6 +166,13 @@ async function run() {
             core.endGroup();
         }
         core.exportVariable('CONTROLLER_NAME', controller_name);
+        core.startGroup("Install kubectl");
+        if (provider === "microk8s") {
+            await exec.exec("sudo snap alias microk8s.kubectl kubectl");
+        } else {
+            await exec.exec("sudo snap install kubectl --classic");
+        }
+        core.endGroup();
     } catch(error) {
         core.setFailed(error.message);
     }


### PR DESCRIPTION
Support for juju-bundle is added to pytest-operator in [PR #31][] so this ensures that it's installed, to support that. It also installs kubectl, or aliases it to microk8s.kubectl if using that provider, so that tests which need it can use it without becoming tightly coupled to the provider.

[PR #31]: https://github.com/charmed-kubernetes/pytest-operator/pull/31