### PR TITLE
Default lxd's channel to "latest/stable"

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -40,6 +40,10 @@ inputs:
     description: "snap channel for juju bundle, installed via snap"
     required: false
     default: "latest/stable"
+  lxd-channel:
+    description: "snap channel for lxd regardless of provider, installed via snap"
+    required: false
+    default: "latest/stable"
 runs:
   using: "node12"
   main: "dist/bootstrap/index.js"

--- a/dist/bootstrap/index.js
+++ b/dist/bootstrap/index.js
@@ -1755,6 +1755,7 @@ function run() {
         const charmcraft_channel = core.getInput("charmcraft-channel");
         const juju_channel = core.getInput("juju-channel");
         const juju_bundle_channel = core.getInput("juju-bundle-channel");
+        const lxd_channel = core.getInput("lxd-channel");
         let bootstrap_constraints = "cores=2 mem=4G";
         let group = "";
         try {
@@ -1766,7 +1767,12 @@ function run() {
             // LXD is now a pre-req for building any charm with charmcraft
             core.startGroup("Install LXD");
             yield exec.exec("sudo apt-get remove -qy lxd lxd-client", [], ignoreFail);
-            yield exec.exec("sudo snap install lxd");
+            // Informational
+            yield exec.exec("sudo snap list lxd", [], ignoreFail);
+            // Install LXD -- If it's installed, rc=0 and a warning about using snap refresh appears
+            yield exec.exec(`sudo snap install lxd --channel=${lxd_channel}`);
+            // Refresh LXD to the desired channel
+            yield exec.exec(`sudo snap refresh lxd --channel=${lxd_channel}`);
             core.endGroup();
             core.startGroup("Initialize LXD");
             yield exec.exec("sudo lxd waitready");

--- a/dist/bootstrap/index.js
+++ b/dist/bootstrap/index.js
@@ -1797,14 +1797,14 @@ function run() {
             core.endGroup();
             let bootstrap_command = `juju bootstrap --debug --verbose ${provider} ${bootstrap_options}`;
             if (provider === "lxd") {
-                if (channel !== null) {
+                if ([null, ""].includes(channel) == false) {
                     yield exec.exec(`sudo snap refresh lxd --channel=${channel}`);
                 }
                 group = "lxd";
             }
             else if (provider === "microk8s") {
                 core.startGroup("Install microk8s");
-                if (channel !== null) {
+                if ([null, ""].includes(channel) == false) {
                     yield exec.exec(`sudo snap install microk8s --classic --channel=${channel}`);
                 }
                 else {
@@ -1824,7 +1824,7 @@ function run() {
                 core.startGroup("Install MicroStack");
                 let os_series = "focal";
                 let os_region = "microstack";
-                if (channel !== null) {
+                if ([null, ""].includes(channel) == false) {
                     yield exec.exec(`sudo snap install microstack --beta --devmode --channel=${channel}`);
                 }
                 else {

--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -108,13 +108,13 @@ async function run() {
         core.endGroup();
         let bootstrap_command = `juju bootstrap --debug --verbose ${provider} ${bootstrap_options}`
         if (provider === "lxd") {
-            if (channel !== null){
+            if ([null, ""].includes(channel) == false){
                 await exec.exec(`sudo snap refresh lxd --channel=${channel}`);
 	        }
             group = "lxd";
         } else if (provider === "microk8s") {
             core.startGroup("Install microk8s");
-            if (channel !== null){
+            if ([null, ""].includes(channel) == false){
                 await exec.exec(`sudo snap install microk8s --classic --channel=${channel}`);
             } else {
                 await exec.exec("sudo snap install microk8s --classic");
@@ -132,7 +132,7 @@ async function run() {
             core.startGroup("Install MicroStack");
             let os_series = "focal";
             let os_region = "microstack";
-    	    if (channel !== null){
+    	    if ([null, ""].includes(channel) == false){
             	await exec.exec(`sudo snap install microstack --beta --devmode --channel=${channel}`);
 	        } else {
             	await exec.exec("sudo snap install microstack --beta --devmode");


### PR DESCRIPTION
 allow an override to other channels, even if LXD isn't the provider

```yaml
  test-with-old-lxd:
    runs-on: ubuntu-latest
    name: Test using old lxd channel
    steps:
      - name: Setup operator environment
        uses: charmed-kubernetes/actions-operator@main
        with:
           lxd-channel: 4.0/stable
```