### PR TITLE
 Adds optional addons for microk8s

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -52,6 +52,10 @@ inputs:
     description: "snap channel for juju-crashdump, installed via snap"
     required: false
     default: "latest/stable"
+  microk8s-addons:
+    description: "microk8s addons to enable"
+    required: false
+    default: "storage dns rbac"
 runs:
   using: "node12"
   main: "dist/bootstrap/index.js"


### PR DESCRIPTION
In order to be able to use the ``nginx-ingress-integrator`` charm and other related charms, we need to enable ``ingress`` in microk8s.

This adds the ``microk8s-addons`` option, which will contain the addons to be enabled in microk8s. If not given, the default addons will be added instead (``storage, dns, rbac``).

Fixes: https://github.com/charmed-kubernetes/actions-operator/issues/32