### PR TITLE
Bump Action runtime to Node16

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: woke
         uses: canonical-web-and-design/inclusive-naming@main
         with:
@@ -28,7 +28,7 @@ jobs:
           - ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: ./
         with:
           provider: lxd
@@ -53,7 +53,7 @@ jobs:
           - latest/stable
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: ./
         with:
           provider: microk8s
@@ -73,7 +73,7 @@ jobs:
           - ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: ./
         with:
           provider: microk8s
@@ -89,7 +89,7 @@ jobs:
     name: Test microstack environment
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: ./
         with:
           provider: microstack
@@ -103,7 +103,7 @@ jobs:
     name: Test vSphere environment
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: ./
         with:
           provider: vsphere

--- a/action.yaml
+++ b/action.yaml
@@ -57,7 +57,7 @@ inputs:
     required: false
     default: ""
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/bootstrap/index.js"
   post: "dist/cleanup/index.js"
 branding:


### PR DESCRIPTION
## Changes
Lately, when running GH actions with the Node12 version throws a deprecation warning. Node12 has been out of support since April 2022 therefore this PR should address this deprecation notice for the actions-operator.
### Further Information
- [Deprecation notice](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)
- [GH Actions Docs](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-javascript-actions)