### PR TITLE
Adds optional addons for microk8s

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -84,25 +84,34 @@ jobs:
         run: |
           tox -e tests -- -k "not machine"
 
-  test-microk8s-addons:
-    name: Test microk8s addons option
+  test-microk8s-default-addons:
+    name: Test default addons are enabled by microk8s provider.
     runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        addons:
-          - ""
-          - []
     steps:
       - name: Check out code
         uses: actions/checkout@v3
       - uses: ./
         with:
           provider: microk8s
-          microk8s-addons: ${{ matrix.addons }}
 
       - name: Run Tests
         run: |
-          tox -e tests -- -k "not machine"
+          tox -e tests -- -k "addons" --addons "storage dns rbac"
+
+  test-microk8s-empty-addons:
+    name: Test passing empty addon list to microk8s provider.
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - uses: ./
+        with:
+          provider: microk8s
+          microk8s-addons: ""
+
+      - name: Run Tests
+        run: |
+          tox -e tests -- -k "addons" --addons ""
 
   test-microstack:
     runs-on: self-hosted

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -98,21 +98,6 @@ jobs:
         run: |
           tox -e tests -- -k "addons" --addons "storage dns rbac"
 
-  test-microk8s-empty-addons:
-    name: Test passing empty addon list to microk8s provider.
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-      - uses: ./
-        with:
-          provider: microk8s
-          microk8s-addons: ""
-
-      - name: Run Tests
-        run: |
-          tox -e tests -- -k "addons" --addons ""
-
   test-microstack:
     runs-on: self-hosted
     name: Test microstack environment

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -48,7 +48,7 @@ jobs:
         os:
           - ubuntu-20.04
           - ubuntu-22.04
-        channel: 
+        channel:
           - 1.23/stable
           - latest/stable
     steps:
@@ -79,6 +79,26 @@ jobs:
           provider: microk8s
           channel: 1.25-strict/stable
           juju-channel: 3.0/stable
+
+      - name: Run Tests
+        run: |
+          tox -e tests -- -k "not machine"
+
+  test-microk8s-addons:
+    name: Test microk8s addons option
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        addons:
+          - ""
+          - []
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - uses: ./
+        with:
+          provider: microk8s
+          microk8s-addons: ${{ matrix.addons }}
 
       - name: Run Tests
         run: |

--- a/README.md
+++ b/README.md
@@ -71,8 +71,7 @@ dns, storage and rbac. You can override these defaults with the following:
           provider: microk8s
           microk8s-addons: "storage dns rbac registry"
 ```
-An empty string in place of the addons, such as `microk8s-addons: ""`, will 
-result in no add-ons being enabled.
+Currently, if specific addons are defined, a minimum set of addons (the defaults) `dns, storage, rbac` must be enabled for the action to work properly.. 
 
 ## pytest-operator
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,23 @@ jobs:
           clouds-yaml: ${{ secrets.CLOUDS_YAML }}
           bootstrap-options: "--model-default datastore=my-datastore"
 ```
+## microk8s provider
+Using the microk8s provider some default add-ons will be enabled - specifically 
+dns, storage and rbac. You can override these defaults with the following:
+
+```yaml
+  add-on-test:
+    runs-on: ubuntu-latest
+    name: Testing custom addons
+    steps:
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: microk8s
+          microk8s-addons: "storage dns rbac registry"
+```
+An empty string in place of the addons, such as `microk8s-addons: ""`, will 
+result in no add-ons being enabled.
 
 ## pytest-operator
 

--- a/action.yaml
+++ b/action.yaml
@@ -56,6 +56,10 @@ inputs:
     description: "microk8s group name"
     required: false
     default: ""
+  microk8s-addons:
+    description: "microk8s addons to enable"
+    required: false
+    default: "storage dns rbac"
 runs:
   using: "node16"
   main: "dist/bootstrap/index.js"

--- a/dist/bootstrap/index.js
+++ b/dist/bootstrap/index.js
@@ -4872,10 +4872,11 @@ function retry_until_rc(cmd, expected_rc = 0, maxRetries = 12, timeout = 10000) 
 function microk8s_init(addons) {
     return __awaiter(this, void 0, void 0, function* () {
         // microk8s needs some additional things done to ensure it's ready for Juju.
-        // Add the given addons.If not were given, enable the default ones.
-        addons = addons || "storage dns rbac";
+        // Add the given addons if any were given.
         yield exec_as_microk8s("microk8s status --wait-ready");
-        yield exec_as_microk8s("sudo microk8s enable " + addons);
+        if (addons) {
+            yield exec_as_microk8s("sudo microk8s enable " + addons);
+        }
         let stdout_buf = '';
         const options = {
             listeners: {

--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -70,10 +70,12 @@ async function retry_until_rc(cmd: string, expected_rc=0, maxRetries=12, timeout
     return false;
 }
 
-async function microk8s_init() {
+async function microk8s_init(addons) {
     // microk8s needs some additional things done to ensure it's ready for Juju.
+    // Add the given addons.If not were given, enable the default ones.
+    addons = addons || "storage dns rbac"
     await exec_as_microk8s("microk8s status --wait-ready");
-    await exec_as_microk8s("sudo microk8s enable storage dns rbac");
+    await exec_as_microk8s("sudo microk8s enable " + addons);
     let stdout_buf = '';
     const options = {
         listeners: {
@@ -126,6 +128,7 @@ async function run() {
     const lxd_channel = core.getInput("lxd-channel");
     const microk8s_group = get_microk8s_group();
     let bootstrap_constraints = core.getInput("bootstrap-constraints");
+    const microk8s_addons = core.getInput("microk8s-addons")
     let group = "";
     try {
         core.addPath('/snap/bin');
@@ -193,7 +196,7 @@ async function run() {
             core.endGroup();
             core.startGroup("Initialize microk8s");
             await exec.exec('bash', ['-c', `sudo usermod -a -G ${microk8s_group} $USER`]);
-            if(!await microk8s_init()) {
+            if(!await microk8s_init(microk8s_addons)) {
                 return;
             }
             group = microk8s_group;

--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -72,10 +72,11 @@ async function retry_until_rc(cmd: string, expected_rc=0, maxRetries=12, timeout
 
 async function microk8s_init(addons) {
     // microk8s needs some additional things done to ensure it's ready for Juju.
-    // Add the given addons.If not were given, enable the default ones.
-    addons = addons || "storage dns rbac"
+    // Add the given addons if any were given.
     await exec_as_microk8s("microk8s status --wait-ready");
-    await exec_as_microk8s("sudo microk8s enable " + addons);
+    if (addons) {
+        await exec_as_microk8s("sudo microk8s enable " + addons);
+    }
     let stdout_buf = '';
     const options = {
         listeners: {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption("--addons", action="store", default=None)
+
+
+@pytest.fixture(scope="session")
+def addons(request):
+    addons = request.config.option.addons
+    if addons is None:
+        pytest.skip()
+    return addons

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -28,7 +28,7 @@ async def test_addons(addons: str):
     addons = set(addons)
     addons = set.union(addons, default_addons)
     result = run(
-        ["microk8s", "status", "--format", "yaml"], capture_output=True
+        ["sudo", "microk8s", "status", "--format", "yaml"], capture_output=True
     )
     status = yaml.safe_load(result.stdout)
     status = status["addons"]

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -3,9 +3,6 @@ from subprocess import run
 import pytest
 import yaml
 
-# Microk8s enables these addons by default
-default_addons = ("ha-cluster", "helm", "helm3")
-
 
 def verify_enabled(addon_list: list, desired_addons: set):
     for addon in addon_list:
@@ -13,8 +10,6 @@ def verify_enabled(addon_list: list, desired_addons: set):
         status = addon["status"]
         if name in desired_addons:
             assert status == "enabled", f"For addon {name}"
-        else:
-            assert status == "disabled", f"For addon {name}"
 
 
 @pytest.mark.abort_on_fail
@@ -26,7 +21,6 @@ async def test_addons(addons: str):
     # Split on spaces
     addons = addons.split()
     addons = set(addons)
-    addons = set.union(addons, default_addons)
     result = run(
         ["sudo", "microk8s", "status", "--format", "yaml"], capture_output=True
     )

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -1,0 +1,35 @@
+from subprocess import run
+
+import pytest
+import yaml
+
+# Microk8s enables these addons by default
+default_addons = ("ha-cluster", "helm", "helm3")
+
+
+def verify_enabled(addon_list: list, desired_addons: set):
+    for addon in addon_list:
+        name = addon["name"]
+        status = addon["status"]
+        if name in desired_addons:
+            assert status == "enabled", f"For addon {name}"
+        else:
+            assert status == "disabled", f"For addon {name}"
+
+
+@pytest.mark.abort_on_fail
+async def test_addons(addons: str):
+    """Tests whether desired addons are enabled.
+    To enable this test add `--addons "ingress dns rbac..."` in your
+    call to pytest.
+    """
+    # Split on spaces
+    addons = addons.split()
+    addons = set(addons)
+    addons = set.union(addons, default_addons)
+    result = run(
+        ["microk8s", "status", "--format", "yaml"], capture_output=True
+    )
+    status = yaml.safe_load(result.stdout)
+    status = status["addons"]
+    verify_enabled(status, addons)

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -31,5 +31,6 @@ async def test_addons(addons: str):
         ["sudo", "microk8s", "status", "--format", "yaml"], capture_output=True
     )
     status = yaml.safe_load(result.stdout)
+    assert status is not None, f"microk8s status = {result}"
     status = status["addons"]
     verify_enabled(status, addons)


### PR DESCRIPTION
This PR replaces #45, which itself extended #33.  The PR originates from @kian99 who does not have permissions in this repo, so the full CI suite cannot be executed.  I'm opening this clone of @kian99's PR so we can get the full test suite.

Copied from #45:
> In order to be able to use the nginx-ingress-integrator charm and other related charms, we need to enable ingress in microk8s.
> 
> > Copied from #33:
> > This adds the microk8s-addons option, which will contain the addons to be enabled in microk8s. If not given, the default addons will be added instead (storage, dns, rbac).
> > 
> This PR can be merged in favor of the original, it simply adds the original changes on top of the latest commit in main. An example use can be found [here](https://github.com/canonical/xyz/actions/runs/3540009136/jobs/5942565602) with corresponding [workflow file](https://github.com/canonical/xyz/actions/runs/3540009136/workflow).

Fixes #32

