### PR TITLE
Skip cleanup for LXD

### DIFF
--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -10220,7 +10220,7 @@ function run() {
         try {
             if (controller_name) {
                 core.addPath('/snap/bin');
-                if (provider !== "microk8s") {
+                if (!["microk8s", "lxd"].includes(provider)) {
                     yield exec.exec(`juju destroy-controller -y ${controller_name} --destroy-all-models --destroy-storage`);
                 }
                 if (provider === "microstack") {

--- a/src/cleanup/index.ts
+++ b/src/cleanup/index.ts
@@ -29,7 +29,7 @@ async function run() {
     try {
         if (controller_name) {
             core.addPath('/snap/bin');
-            if (provider !== "microk8s") {
+            if (!["microk8s", "lxd"].includes(provider)) {
                 await exec.exec(`juju destroy-controller -y ${controller_name} --destroy-all-models --destroy-storage`);
             }
             if (provider === "microstack") {


### PR DESCRIPTION
Destroying the controller can add an extra 5 minutes to a GitHub Actions run when a test is cancelled (example: https://github.com/canonical/mysql-operator/actions/runs/3875935803/jobs/6609158840). If a test stalls & needs to be re-run; this means the person who cancels the test has to wait 5 minutes to start a re-run

Closes #19 

Related issues #20, #22