### PR TITLE
Add test to assert retriable snap commands work

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -128,3 +128,31 @@ jobs:
       - name: Run Tests
         run: |
           tox -e tests -- -k "not k8s"
+
+  test-microk8s-with-flaky-snap:
+    name: Test microk8s environment with a flaky snap command
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-20.04
+          - ubuntu-22.04
+        channel:
+          - latest/stable
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      # Replace `snap` with something that randomly fails 1/10 executions
+      - name: Replace snap with a flaky snap
+        run: |
+          sudo mv /usr/bin/snap /usr/bin/snap_real
+          sudo mv ./tests/flaky_snap.sh /usr/bin/snap
+          sudo chmod a+x /usr/bin/snap
+      - uses: ./
+        with:
+          provider: microk8s
+          channel: ${{ matrix.channel }}
+
+      - name: Run Tests
+        run: |
+          tox -e tests -- -k "not machine"

--- a/tests/flaky_snap.sh
+++ b/tests/flaky_snap.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+X="$RANDOM"
+echo Command will fail if $X \% 10 == 0
+if [[ "$((X % 10))" -eq 0 ]]; then
+	echo snap command failed randomly
+else
+	snap_real "$@"
+fi


### PR DESCRIPTION
Adds a flaky `snap` command to the mix, to ensure that sometimes the `snap` command will fail during testing.