### PR TITLE
pinning juju snap channels

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -31,11 +31,11 @@ inputs:
   charm-channel:
     description: "snap channel for charm, installed via snap"
     required: false
-    default: "3.x/stable"
+    default: "latest/stable"
   charmcraft-channel:
     description: "snap channel for charmcraft, installed via snap"
     required: false
-    default: "2.2/stable"
+    default: "latest/stable"
   juju-channel:
     description: "snap channel for juju, installed via snap"
     required: false
@@ -47,7 +47,7 @@ inputs:
   lxd-channel:
     description: "snap channel for lxd regardless of provider, installed via snap"
     required: false
-    default: "5.10/stable"
+    default: "latest/stable"
   juju-crashdump-channel:
     description: "snap channel for juju-crashdump, installed via snap"
     required: false

--- a/action.yaml
+++ b/action.yaml
@@ -31,15 +31,15 @@ inputs:
   charm-channel:
     description: "snap channel for charm, installed via snap"
     required: false
-    default: "latest/stable"
+    default: "3.x/stable"
   charmcraft-channel:
     description: "snap channel for charmcraft, installed via snap"
     required: false
-    default: "latest/stable"
+    default: "2.2/stable"
   juju-channel:
     description: "snap channel for juju, installed via snap"
     required: false
-    default: "latest/stable"
+    default: "2.9/stable"
   juju-bundle-channel:
     description: "snap channel for juju bundle, installed via snap"
     required: false
@@ -47,7 +47,7 @@ inputs:
   lxd-channel:
     description: "snap channel for lxd regardless of provider, installed via snap"
     required: false
-    default: "latest/stable"
+    default: "5.10/stable"
   juju-crashdump-channel:
     description: "snap channel for juju-crashdump, installed via snap"
     required: false

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ setenv =
 
 [testenv:tests]
 deps =
-    juju
+    juju < 3.1
     pytest
     pytest-operator
  


### PR DESCRIPTION
Pin to juju-channel 2.9/stable as the default until more charms ready their test harnesses to use 3.x

Any adjustments to these snap versions should be made by the actions operator caller

```yaml
    - name: Setup operator environment
      uses: charmed-kubernetes/actions-operator@main
      with:
        juju-channel: <juju channel>
```
