### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,8 @@ Building using npm:
 
 ```
 sudo apt install npm  # install npm, if needed
-npm install           # install / update dependencies
+export NODE_OPTIONS=--openssl-legacy-provider
+npm install           # install dependencies
 npm run build
 ```
+


### PR DESCRIPTION
without env var get

```
> actions-operator@0.1.0 build
> ncc build src/bootstrap/index.ts -o dist/bootstrap --license licenses.txt && ncc build src/cleanup/index.ts -o dist/cleanup --license licenses.txt

ncc: Version 0.27.0
ncc: Compiling file index.js
Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:71:19)
    at Object.createHash (node:crypto:133:10)
    at hashOf (/home/maksim/git/actions-operator/node_modules/@vercel/ncc/dist/ncc/index.js.cache.js:1:3253134)
    at ncc (/home/maksim/git/actions-operator/node_modules/@vercel/ncc/dist/ncc/index.js.cache.js:1:3256648)
    at runCmd (/home/maksim/git/actions-operator/node_modules/@vercel/ncc/dist/ncc/cli.js.cache.js:1:51537)
    at 819 (/home/maksim/git/actions-operator/node_modules/@vercel/ncc/dist/ncc/cli.js.cache.js:1:48344)
    at __webpack_require__ (/home/maksim/git/actions-operator/node_modules/@vercel/ncc/dist/ncc/cli.js.cache.js:1:55043)
    at /home/maksim/git/actions-operator/node_modules/@vercel/ncc/dist/ncc/cli.js.cache.js:1:55194
    at /home/maksim/git/actions-operator/node_modules/@vercel/ncc/dist/ncc/cli.js.cache.js:1:55220
    at Object.<anonymous> (/home/maksim/git/actions-operator/node_modules/@vercel/ncc/dist/ncc/cli.js:8:28) {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}
```
