### PR TITLE
Makes juju and microk8s classic confinement optional

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -44,6 +44,10 @@ inputs:
     description: "snap channel for juju bundle, installed via snap"
     required: false
     default: "latest/stable"
+  juju-classic-confinement:
+    description: "Install juju with classic confinement"
+    required: false
+    default: "true"
   lxd-channel:
     description: "snap channel for lxd regardless of provider, installed via snap"
     required: false
@@ -60,6 +64,10 @@ inputs:
     description: "microk8s addons to enable"
     required: false
     default: "storage dns rbac"
+  microk8s-classic-confinement:
+    description: "Install microk8s with classic confinement"
+    required: false
+    default: "true"
 runs:
   using: "node16"
   main: "dist/bootstrap/index.js"

--- a/dist/bootstrap/index.js
+++ b/dist/bootstrap/index.js
@@ -5579,8 +5579,10 @@ function run() {
         const juju_channel = core.getInput("juju-channel");
         const juju_bundle_channel = core.getInput("juju-bundle-channel");
         const juju_crashdump_channel = core.getInput("juju-crashdump-channel");
+        const juju_classic_confinement = core.getInput("juju-classic-confinement") == "true" ? "--classic" : "";
         const lxd_channel = core.getInput("lxd-channel");
         const microk8s_group = get_microk8s_group();
+        const microk8s_classic_confinement = core.getInput("microk8s-classic-confinement") == "true" ? "--classic" : "";
         let bootstrap_constraints = core.getInput("bootstrap-constraints");
         const microk8s_addons = core.getInput("microk8s-addons");
         let group = "";
@@ -5613,7 +5615,7 @@ function run() {
             yield exec.exec("sudo --preserve-env=http_proxy,https_proxy,no_proxy pip3 install tox");
             core.endGroup();
             core.startGroup("Install Juju");
-            yield snap(`install juju --classic --channel=${juju_channel}`);
+            yield snap(`install juju ${juju_classic_confinement} --channel=${juju_channel}`);
             core.endGroup();
             core.startGroup("Install tools");
             yield snap("install jq");
@@ -5642,10 +5644,10 @@ function run() {
             else if (provider === "microk8s") {
                 core.startGroup("Install microk8s");
                 if ([null, ""].includes(channel) == false) {
-                    yield snap(`install microk8s --classic --channel=${channel}`);
+                    yield snap(`install microk8s ${microk8s_classic_confinement} --channel=${channel}`);
                 }
                 else {
-                    yield snap("install microk8s --classic");
+                    yield snap(`install microk8s ${microk8s_classic_confinement}`);
                 }
                 core.endGroup();
                 core.startGroup("Initialize microk8s");


### PR DESCRIPTION
Adds inputs `juju-classic-confinement` and `microk8s-classic-confinement` (on by default, i.e. not a breaking change) to allow optionally for using the strictly confined versions of `juju` and `microk8s`.