### PR TITLE
Fix unnecessary delay in setting up microk8s

### DIFF
--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -106,7 +106,7 @@ async function microk8s_init(addons) {
     }
 
     await retry_until_rc("microk8s kubectl auth can-i create pods")
-    await retry_until_rc("microk8s kubectl auth can-i create pods --as=me", 1)
+    await retry_until_rc("microk8s kubectl auth can-i create pods --as=me")
     return true;
 }
 


### PR DESCRIPTION
This change prevents the `can-i` command from waiting until a return code of 1. A success is return code 0, and the current behavior is to retry 12 times with a delay of 10 seconds, wasting 2 minutes of runner time for no reason.