### PR TITLE
Validate return codes when initializing microk8s

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "es6",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "lib": ["es2017"],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
Without this change, if the `can-i` commands failed, the build would ignore it and continue after 2 minutes.

Furthermore, the `can-i --as=me` command is only relevant when RBAC is enabled, so this change also checks for that before waiting on that command. Subtly introduced in https://github.com/charmed-kubernetes/actions-operator/pull/46 when addons were made configurable.

Admittedly, I was unsure how to test this locally, so I'm depending a bit on the e2e tests here.