### PR TITLE
feat: enable timeout on microk8s wait ready

### DIFF
--- a/dist/bootstrap/index.js
+++ b/dist/bootstrap/index.js
@@ -5596,7 +5596,7 @@ function microk8s_init(channel, addons, container_registry_url) {
             yield exec.exec("sudo", ["microk8s", "start"]);
         }
         // Add the given addons if any were given.
-        yield exec_as_microk8s("microk8s status --wait-ready");
+        yield exec_as_microk8s("microk8s status --wait-ready --timeout=600");
         if (addons) {
             yield exec_as_microk8s("sudo microk8s enable " + addons);
         }

--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -118,7 +118,7 @@ async function microk8s_init(channel, addons, container_registry_url:string) {
     }
 
     // Add the given addons if any were given.
-    await exec_as_microk8s("microk8s status --wait-ready");
+    await exec_as_microk8s("microk8s status --wait-ready --timeout=600");
     if (addons) {
         await exec_as_microk8s("sudo microk8s enable " + addons);
     }


### PR DESCRIPTION
We've encountered an issue where microk8s, when using dockerhub-registry, the cache was serving corrupt images. This made microk8s unable to start and wait-ready was stuck for 6hours+.

To mitigate such behaviors, we add a timeout of 10mins.