### PR TITLE
Only install and refresh lxd once

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -30,15 +30,13 @@ jobs:
           - '2.9'
           - '3.1'
           - '3.3'
-        lxd:
-          - '5.20'
     steps:
       - name: Check out code
         uses: actions/checkout@v3
       - uses: ./
         with:
           provider: lxd
-          channel: ${{ matrix.lxd }}
+          channel: latest/stable
           juju-channel: ${{ matrix.juju }}/stable
 
       - name: Run 3.x Tests
@@ -71,7 +69,6 @@ jobs:
         with:
           provider: microk8s
           channel: ${{ matrix.channel }}
-          lxd-channel: 5.20/stable
 
       - name: Run Tests
         run: |
@@ -96,7 +93,6 @@ jobs:
           provider: microk8s
           channel: ${{ matrix.channel }}
           juju-channel: 2.9/stable
-          lxd-channel: 5.20/stable
 
       - name: Run Tests
         run: |
@@ -142,7 +138,6 @@ jobs:
           provider: vsphere
           credentials-yaml: ${{ secrets.CREDENTIALS_YAML }}
           clouds-yaml: ${{ secrets.CLOUDS_YAML }}
-          lxd-channel: 5.20/stable
           bootstrap-options: "--model-default datastore=vsanDatastore --model-default primary-network=VLAN_2764 --bootstrap-image=juju-ci-root/templates/jammy-test-template --bootstrap-series=jammy"
           bootstrap-constraints: "arch=amd64 cores=2 mem=4G"
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -30,13 +30,15 @@ jobs:
           - '2.9'
           - '3.1'
           - '3.3'
+        lxd:
+          - '5.20'
     steps:
       - name: Check out code
         uses: actions/checkout@v3
       - uses: ./
         with:
           provider: lxd
-          channel: latest/stable
+          channel: ${{ matrix.lxd }}
           juju-channel: ${{ matrix.juju }}/stable
 
       - name: Run 3.x Tests
@@ -52,7 +54,7 @@ jobs:
           exit $?
 
   test-microk8s-strict:
-    name: Test microk8s environment
+    name: Test microk8s strict
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -69,13 +71,14 @@ jobs:
         with:
           provider: microk8s
           channel: ${{ matrix.channel }}
+          lxd-channel: 5.20/stable
 
       - name: Run Tests
         run: |
           tox -e tests -- -k "not machine"
 
   test-microk8s-classic:
-    name: Test microk8s classic environment
+    name: Test microk8s classic
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -93,6 +96,7 @@ jobs:
           provider: microk8s
           channel: ${{ matrix.channel }}
           juju-channel: 2.9/stable
+          lxd-channel: 5.20/stable
 
       - name: Run Tests
         run: |
@@ -138,6 +142,7 @@ jobs:
           provider: vsphere
           credentials-yaml: ${{ secrets.CREDENTIALS_YAML }}
           clouds-yaml: ${{ secrets.CLOUDS_YAML }}
+          lxd-channel: 5.20/stable
           bootstrap-options: "--model-default datastore=vsanDatastore --model-default primary-network=VLAN_2764 --bootstrap-image=juju-ci-root/templates/jammy-test-template --bootstrap-series=jammy"
           bootstrap-constraints: "arch=amd64 cores=2 mem=4G"
 

--- a/action.yaml
+++ b/action.yaml
@@ -45,7 +45,10 @@ inputs:
     required: false
     default: "latest/stable"
   lxd-channel:
-    description: "snap channel for lxd regardless of provider, installed via snap"
+    description: |-
+      snap channel for lxd, installed via snap
+
+      Ignored if inputs.provider="lxd" and inputs.channel is non-empty
     required: false
     default: "latest/stable"
   juju-crashdump-channel:

--- a/action.yaml
+++ b/action.yaml
@@ -39,7 +39,7 @@ inputs:
   juju-channel:
     description: "snap channel for juju, installed via snap"
     required: false
-    default: "latest/stable"
+    default: "3/stable"
   juju-bundle-channel:
     description: "snap channel for juju bundle, installed via snap"
     required: false

--- a/dist/bootstrap/index.js
+++ b/dist/bootstrap/index.js
@@ -5674,7 +5674,7 @@ function run() {
         const juju_channel = core.getInput("juju-channel");
         const juju_bundle_channel = core.getInput("juju-bundle-channel");
         const juju_crashdump_channel = core.getInput("juju-crashdump-channel");
-        const lxd_channel = (provider === "lxd" && ![null, ""].includes(channel)) ? channel : core.getInput("lxd-channel");
+        const lxd_channel = (provider === "lxd" && channel) ? channel : core.getInput("lxd-channel");
         const microk8s_group = get_microk8s_group();
         let bootstrap_constraints = core.getInput("bootstrap-constraints");
         const microk8s_addons = core.getInput("microk8s-addons");

--- a/dist/bootstrap/index.js
+++ b/dist/bootstrap/index.js
@@ -5674,7 +5674,7 @@ function run() {
         const juju_channel = core.getInput("juju-channel");
         const juju_bundle_channel = core.getInput("juju-bundle-channel");
         const juju_crashdump_channel = core.getInput("juju-crashdump-channel");
-        const lxd_channel = core.getInput("lxd-channel");
+        const lxd_channel = (provider === "lxd" && ![null, ""].includes(channel)) ? channel : core.getInput("lxd-channel");
         const microk8s_group = get_microk8s_group();
         let bootstrap_constraints = core.getInput("bootstrap-constraints");
         const microk8s_addons = core.getInput("microk8s-addons");
@@ -5730,10 +5730,9 @@ function run() {
             yield exec.exec("mkdir", ["-p", juju_dir]);
             let bootstrap_command = `juju bootstrap --debug --verbose ${provider} ${bootstrap_options}`;
             if (provider === "lxd") {
-                if ([null, ""].includes(channel) == false) {
-                    yield snap(`refresh lxd --channel=${channel}`);
-                }
+                core.startGroup("Preparing LXD Provider");
                 group = "lxd";
+                core.endGroup();
             }
             else if (provider === "microk8s") {
                 core.startGroup("Install microk8s");
@@ -5783,10 +5782,12 @@ function run() {
                 bootstrap_constraints = `${bootstrap_constraints} allocate-public-ip=true`;
             }
             else if (credentials_yaml != "") {
+                core.startGroup(`Preparing Provider ${provider} credentials`);
                 yield exec.exec("bash", ["-c", `echo "${credentials_yaml}" | base64 -d > ${juju_dir}/credentials.yaml`], options);
                 if (clouds_yaml != "") {
                     yield exec.exec("bash", ["-c", `echo "${clouds_yaml}" | base64 -d > ${juju_dir}/clouds.yaml`], options);
                 }
+                core.endGroup();
             }
             else {
                 core.setFailed(`Custom provider set without credentials: ${provider}`);

--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -195,7 +195,7 @@ async function run() {
     const juju_bundle_channel = core.getInput("juju-bundle-channel");
     const juju_crashdump_channel = core.getInput("juju-crashdump-channel")
     
-    const lxd_channel = (provider === "lxd" && ! [null, ""].includes(channel)) ? channel : core.getInput("lxd-channel");
+    const lxd_channel = (provider === "lxd" && channel) ? channel : core.getInput("lxd-channel");
 
     const microk8s_group = get_microk8s_group();
     let bootstrap_constraints = core.getInput("bootstrap-constraints");


### PR DESCRIPTION
These changes only refresh the lxd snap to a single channel, rather than allowing it to flip to channels during setup


In the event the workflow is called like this:
```yaml
   provider: lxd
   channel: 5.19
   lxd-channel: <unset>
```

lxd-channel defaults to `latest/stable`

this causes the action to 

```bash
snap refresh lxd --channel=latest/stable
...
snap refresh lxd --channel=5.19
```

Rather than going through jumps here, let's let the action install the correct one at the beginning. 
 