### PR TITLE
Update Node Runtime Version

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -66,7 +66,7 @@ inputs:
   container-registry-url:
     description: "Container registry to use"
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/bootstrap/index.js"
   post: "dist/cleanup/index.js"
 branding:


### PR DESCRIPTION
## Overview
This pull request updates the base node runtime version to Node20. Node 16 is EOL, and Github suggests updating the base node runtime: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/