### PR TITLE
Pin non canonical owned snaps unless workflow specifically overrides

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -41,9 +41,11 @@ inputs:
     required: false
     default: "3/stable"
   juju-bundle-channel:
-    description: "snap channel for juju bundle, installed via snap"
+    description: |-
+      snap channel for juju bundle, installed via snap
+      if unset, uses a stable revision
     required: false
-    default: "latest/stable"
+    default: ""
   lxd-channel:
     description: |-
       snap channel for lxd, installed via snap
@@ -52,9 +54,11 @@ inputs:
     required: false
     default: "latest/stable"
   juju-crashdump-channel:
-    description: "snap channel for juju-crashdump, installed via snap"
+    description: |-
+      snap channel for juju-crashdump, installed via snap
+      if unset, uses a stable revision
     required: false
-    default: "latest/stable"
+    default: ""
   microk8s-group:
     description: "microk8s group name"
     required: false

--- a/dist/bootstrap/index.js
+++ b/dist/bootstrap/index.js
@@ -5658,6 +5658,13 @@ function snap_install(name, channel = "", classic = true) {
         yield snap(args.join(" "));
     });
 }
+function fixed_revision_args(app, channel) {
+    const pinning = { "juju-bundle": 25, "jq": 6, "juju-crashdump": 271 };
+    if (!channel) {
+        return `--revision=${pinning[app]}`;
+    }
+    return `--channel=${channel}`;
+}
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         const HOME = process.env["HOME"];
@@ -5712,11 +5719,11 @@ function run() {
             yield snap_install("juju", juju_channel, juju_channel.includes("2.9"));
             core.endGroup();
             core.startGroup("Install tools");
-            yield snap("install jq");
             yield snap(`install charm --classic --channel=${charm_channel}`);
             yield snap(`install charmcraft --classic --channel=${charmcraft_channel}`);
-            yield snap(`install juju-bundle --classic --channel=${juju_bundle_channel}`);
-            yield snap(`install juju-crashdump --classic --channel=${juju_crashdump_channel}`);
+            yield snap(`install jq ${fixed_revision_args("jq", "")}`);
+            yield snap(`install juju-bundle --classic ${fixed_revision_args("juju-bundle", juju_bundle_channel)}`);
+            yield snap(`install juju-crashdump --classic ${fixed_revision_args("juju-crashdump", juju_crashdump_channel)}`);
             const release = yield os_release();
             if (release["VERSION_CODENAME"].includes("jammy")) {
                 yield docker_lxd_clash();

--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -178,6 +178,14 @@ async function snap_install(name: string, channel: string="", classic: boolean=t
     await snap(args.join(" "))
 }
 
+function fixed_revision_args(app:string, channel:string): string{
+    const pinning = {"juju-bundle": 25, "jq": 6, "juju-crashdump": 271};
+    if (!channel) {
+        return `--revision=${pinning[app]}`
+    }
+    return `--channel=${channel}`
+}
+
 async function run() {
     const HOME = process.env["HOME"]
     const GITHUB_SHA = process.env["GITHUB_SHA"].slice(0, 5)
@@ -234,11 +242,14 @@ async function run() {
         await snap_install("juju", juju_channel, juju_channel.includes("2.9"));
         core.endGroup();
         core.startGroup("Install tools");
-        await snap("install jq");
         await snap(`install charm --classic --channel=${charm_channel}`);
         await snap(`install charmcraft --classic --channel=${charmcraft_channel}`);
-        await snap(`install juju-bundle --classic --channel=${juju_bundle_channel}`);
-        await snap(`install juju-crashdump --classic --channel=${juju_crashdump_channel}`)
+
+
+        await snap(`install jq ${fixed_revision_args("jq", "")}`);
+        await snap(`install juju-bundle --classic ${fixed_revision_args("juju-bundle", juju_bundle_channel)}`);
+        await snap(`install juju-crashdump --classic ${fixed_revision_args("juju-crashdump", juju_crashdump_channel)}`)
+
 
         const release = await os_release();
         if (release["VERSION_CODENAME"].includes("jammy")){


### PR DESCRIPTION
* Changes the default channels for `juju-bundle` and `juju-crashdump` to use stable revisions of those snaps
* Pins snaps of non-canonical origin to stable revisions 
   * `jq`
   * `juju-bundle`
   * `juju-crashdump`