### PR TITLE
Add juju 3.4 and 3.5 to CI

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -27,9 +27,11 @@ jobs:
           - ubuntu-20.04
           - ubuntu-22.04
         juju:
-          - '2.9'
-          - '3.1'
-          - '3.3'
+          - '2.9/stable'
+          - '3.1/stable'
+          - '3.3/stable'
+          - '3.4/stable'
+          - '3.5/edge'
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -37,16 +39,16 @@ jobs:
         with:
           provider: lxd
           channel: latest/stable
-          juju-channel: ${{ matrix.juju }}/stable
+          juju-channel: ${{ matrix.juju }}
 
-      - name: Run 3.x Tests
-        if : ${{ fromJSON(matrix.juju) > 3 }}
+      - name: Run Tests for != 2.x
+        if : ${{ startsWith(matrix.juju, 2) != true }}
         run: |
           tox -e tests -- -k "not k8s"
           exit $?
 
       - name: Run 2.9 Tests
-        if : ${{ fromJSON(matrix.juju) < 3 }}
+        if : ${{ startsWith(matrix.juju, 2) == true }}
         run: |
           tox -e 2.9-tests -- -k "not k8s"
           exit $?


### PR DESCRIPTION
Also refactors workflow matrix to allow testing different juju risks.

Currently uses 3.5/edge because /stable is not released, but we can bump that in a few days. 