### PR TITLE
fix: Install jq from deb to support arm64

### DIFF
--- a/dist/bootstrap/index.js
+++ b/dist/bootstrap/index.js
@@ -5721,7 +5721,7 @@ function run() {
             core.startGroup("Install tools");
             yield snap(`install charm --classic --channel=${charm_channel}`);
             yield snap(`install charmcraft --classic --channel=${charmcraft_channel}`);
-            yield snap(`install jq ${fixed_revision_args("jq", "")}`);
+            yield apt_get("install -yqq jq");
             yield snap(`install juju-bundle --classic ${fixed_revision_args("juju-bundle", juju_bundle_channel)}`);
             yield snap(`install juju-crashdump --classic ${fixed_revision_args("juju-crashdump", juju_crashdump_channel)}`);
             const release = yield os_release();

--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -246,7 +246,7 @@ async function run() {
         await snap(`install charmcraft --classic --channel=${charmcraft_channel}`);
 
 
-        await snap(`install jq ${fixed_revision_args("jq", "")}`);
+        await apt_get("install -yqq jq");
         await snap(`install juju-bundle --classic ${fixed_revision_args("juju-bundle", juju_bundle_channel)}`);
         await snap(`install juju-crashdump --classic ${fixed_revision_args("juju-crashdump", juju_crashdump_channel)}`)
 


### PR DESCRIPTION
This changes the action to install `jq` from the apt repository instead of a snap, to enable the action to work on `arm64`.

The action currently installs `jq` from a specific snap revision that only exists for `amd64`. There is a `jq` deb in main; it is supported on more architectures and is more up to date.

The snap also exists for `arm64`, but we would have to track the `latest/stable` track. This could change more often than the deb package, which is why I propose this change with the deb instead.