### PR TITLE
Ensure that .kube/config is written once microk8s is active

### DIFF
--- a/tests/test_deploy_k8s.py
+++ b/tests/test_deploy_k8s.py
@@ -1,7 +1,15 @@
 import pytest
+from subprocess import check_output
 
 
 @pytest.mark.abort_on_fail
 async def test_build(ops_test):
     await ops_test.model.deploy("ch:minio")
     await ops_test.model.wait_for_idle()
+
+
+@pytest.mark.usefixtures("ops_test")
+async def test_kubectl():
+    # Confirms that kubectl has access to a functional kubeconfig @ $HOME/.kube/config
+    out = check_output(["kubectl", "get", "pods", "-A"], text=True)
+    assert "kube-system" in out, "should see some kube-system pods"


### PR DESCRIPTION
### Overview
Addresses regression from #82 raised in #84 
---
since sg no longer is running commands, we can't use the shell redirects it used to employ -- one such redirect was for writing the .kube/config out to a file. 

### Details
* Created a `checkOutput` method to more easily capture output from stdout
* created a `microk8sKubeConfig` method to capture output from a `exec_as_microk8s` call and write to a file
* add an integration test to confirm that `kubectl` works out of the box
