### PR TITLE
chore: update concierge config format

### DIFF
--- a/src/bootstrap/main.sh
+++ b/src/bootstrap/main.sh
@@ -118,12 +118,18 @@ EOF
     cat <<EOF >> concierge.yaml
 host:
   snaps:
-    - charm/${charm_channel}
-    - charmcraft/${charmcraft_channel}
-    - jq/${jq_channel}
-    - juju-bundle/${juju_bundle_channel}
-    - juju-crashdump/${juju_crashdump_channel}
-    - kubectl
+    charm:
+      channel: ${charm_channel}
+    charmcraft:
+      channel: ${charmcraft_channel}
+    jq:
+      channel: ${jq_channel}
+    juju-bundle:
+      channel: ${juju_bundle_channel}
+    juju-crashdump:
+      channel: ${juju_crashdump_channel}
+    kubectl:
+      channel: stable
 EOF
 
     echo "::group::Concierge (concierge.yaml):"


### PR DESCRIPTION
The format of concierge's config has changed slightly to enable the specification of both a channel, but also a list of connections that should be made.

See [here](https://github.com/jnsgruk/concierge/blob/main/tests/extra-packages-config-file/concierge.yaml) for an example.