### PR TITLE
Use coredns charm rather than minio

### DIFF
--- a/tests/test_deploy_k8s.py
+++ b/tests/test_deploy_k8s.py
@@ -1,10 +1,11 @@
 import pytest
 from subprocess import check_output
 
+from pytest_operator.plugin import OpsTest
 
 @pytest.mark.abort_on_fail
-async def test_build(ops_test):
-    await ops_test.model.deploy("ch:minio")
+async def test_charm_deploy(ops_test : OpsTest):
+    await ops_test.model.deploy("ch:coredns", trust=True)
     await ops_test.model.wait_for_idle()
 
 


### PR DESCRIPTION
### Overview

ch:minio latest/stable charm was removed from Charmhub, so let's replace it with one that likely won't be removed for a while. 