### PR TITLE
swap pip with pipx

### DIFF
--- a/dist/bootstrap/index.js
+++ b/dist/bootstrap/index.js
@@ -5710,7 +5710,6 @@ function install_tox(tox_version = "") {
         const version = tox_version ? `==${tox_version}` : "";
         const pip_path = (yield checkOutput("which", ["pip"], ignoreFail)).trim();
         const is_sys_pip = pip_path === SYSTEM_PIP_PATH;
-        core.info(`PIP PATH: ${pip_path} is sys pip: ${is_sys_pip}`);
         // Avoid installing on system managed Python which may break system dependencies.
         if (pip_path && !is_sys_pip) {
             core.info(`externally managed pip is available, installing tox${version}`);
@@ -5723,7 +5722,7 @@ function install_tox(tox_version = "") {
             yield exec.exec(`pipx install tox${version}`);
             return;
         }
-        core.info("Neither tox nor pipx are available, install pipx via apt then tox");
+        core.info("Neither pip, pipx nor tox are available, install pipx via apt then tox");
         yield apt_get("update -yqq");
         yield apt_get("install -yqq pipx");
         yield exec.exec("pipx ensurepath");

--- a/dist/bootstrap/index.js
+++ b/dist/bootstrap/index.js
@@ -5709,11 +5709,11 @@ function install_tox(tox_version = "") {
         const hasPipx = yield exec.exec("which pipx", [], ignoreFail);
         const version = tox_version ? `==${tox_version}` : "";
         if (hasPipx === 0) {
-            core.info(`pipx ins available, installing tox${version}`);
+            core.info(`pipx is available, installing tox${version}`);
             yield exec.exec(`pipx install tox${version}`);
             return;
         }
-        core.info("Neither tox nor pip are available, install pipx via apt then tox");
+        core.info("Neither tox nor pipx are available, install pipx via apt then tox");
         yield apt_get("update -yqq");
         yield apt_get("install -yqq pipx");
         yield exec.exec("pipx ensurepath");

--- a/dist/bootstrap/index.js
+++ b/dist/bootstrap/index.js
@@ -5492,11 +5492,11 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const core = __importStar(__nccwpck_require__(2186));
 const exec = __importStar(__nccwpck_require__(1514));
-const os = __importStar(__nccwpck_require__(2087));
 const fs = __importStar(__nccwpck_require__(5747));
-const utils_1 = __nccwpck_require__(2828);
+const os = __importStar(__nccwpck_require__(2087));
 const semver_1 = __importDefault(__nccwpck_require__(1383));
 const ts_dedent_1 = __importDefault(__nccwpck_require__(3604));
+const utils_1 = __nccwpck_require__(2828);
 const ignoreFail = { "ignoreReturnCode": true };
 const user = os.userInfo().username;
 const checkOutput = (cmd, args, options) => __awaiter(void 0, void 0, void 0, function* () {
@@ -5706,18 +5706,19 @@ function install_tox(tox_version = "") {
             exec.exec("tox --version");
             return;
         }
-        const hasPip = yield exec.exec("which pip", [], ignoreFail);
+        const hasPipx = yield exec.exec("which pipx", [], ignoreFail);
         const version = tox_version ? `==${tox_version}` : "";
-        if (hasPip == 0) {
-            core.info(`pip is available, install tox${version}`);
-            yield exec.exec(`pip install tox${version}`);
+        if (hasPipx === 0) {
+            core.info(`pipx ins available, installing tox${version}`);
+            yield exec.exec(`pipx install tox${version}`);
+            return;
         }
-        else {
-            core.info("Neither tox nor pip are available, install python3-pip via apt, then tox");
-            yield apt_get("update -yqq");
-            yield apt_get("install -yqq python3-pip");
-            yield exec.exec(`sudo --preserve-env=http_proxy,https_proxy,no_proxy pip3 install tox${version}`);
-        }
+        core.info("Neither tox nor pip are available, install pipx via apt then tox");
+        yield apt_get("update -yqq");
+        yield apt_get("install -yqq pipx");
+        yield exec.exec("pipx ensurepath");
+        yield exec.exec("sudo pipx ensurepath");
+        yield exec.exec(`sudo --preserve-env=http_proxy,https_proxy,no_proxy pipx install tox${version}`);
     });
 }
 function run() {

--- a/dist/bootstrap/index.js
+++ b/dist/bootstrap/index.js
@@ -5710,6 +5710,7 @@ function install_tox(tox_version = "") {
         const version = tox_version ? `==${tox_version}` : "";
         const pip_path = yield checkOutput("which", ["pip"], ignoreFail);
         const is_sys_pip = pip_path === SYSTEM_PIP_PATH;
+        core.info(`PIP PATH: ${pip_path} is sys pip: ${is_sys_pip}`);
         // Avoid installing on system managed Python which may break system dependencies.
         if (pip_path && !is_sys_pip) {
             core.info(`externally managed pip is available, installing tox${version}`);

--- a/dist/bootstrap/index.js
+++ b/dist/bootstrap/index.js
@@ -5708,7 +5708,7 @@ function install_tox(tox_version = "") {
             return;
         }
         const version = tox_version ? `==${tox_version}` : "";
-        const pip_path = yield checkOutput("which", ["pip"], ignoreFail);
+        const pip_path = (yield checkOutput("which", ["pip"], ignoreFail)).trim();
         const is_sys_pip = pip_path === SYSTEM_PIP_PATH;
         core.info(`PIP PATH: ${pip_path} is sys pip: ${is_sys_pip}`);
         // Avoid installing on system managed Python which may break system dependencies.

--- a/dist/bootstrap/index.js
+++ b/dist/bootstrap/index.js
@@ -5718,7 +5718,7 @@ function install_tox(tox_version = "") {
         yield apt_get("install -yqq pipx");
         yield exec.exec("pipx ensurepath");
         yield exec.exec("sudo pipx ensurepath");
-        yield exec.exec(`sudo --preserve-env=http_proxy,https_proxy,no_proxy pipx install tox${version}`);
+        yield exec.exec(`pipx install tox${version}`);
     });
 }
 function run() {

--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -234,7 +234,7 @@ async function install_tox(tox_version: string = "") {
         return;
     }
     const version = tox_version ? `==${tox_version}` : "";
-    const pip_path = await checkOutput("which", ["pip"], ignoreFail);
+    const pip_path = (await checkOutput("which", ["pip"], ignoreFail)).trim();
     const is_sys_pip = pip_path === SYSTEM_PIP_PATH;
     core.info(`PIP PATH: ${pip_path} is sys pip: ${is_sys_pip}`)
     // Avoid installing on system managed Python which may break system dependencies.

--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -236,6 +236,7 @@ async function install_tox(tox_version: string = "") {
     const version = tox_version ? `==${tox_version}` : "";
     const pip_path = await checkOutput("which", ["pip"], ignoreFail);
     const is_sys_pip = pip_path === SYSTEM_PIP_PATH;
+    core.info(`PIP PATH: ${pip_path} is sys pip: ${is_sys_pip}`)
     // Avoid installing on system managed Python which may break system dependencies.
     if (pip_path && !is_sys_pip) {
         core.info(`externally managed pip is available, installing tox${version}`)

--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -1,10 +1,10 @@
 import * as core from '@actions/core';
 import * as exec from '@actions/exec';
-import * as os from 'os'
 import * as fs from 'fs';
-import { retryAsyncDecorator } from 'ts-retry/lib/cjs/retry/utils';
+import * as os from 'os';
 import semver from 'semver';
 import dedent from 'ts-dedent';
+import { retryAsyncDecorator } from 'ts-retry/lib/cjs/retry/utils';
 
 declare var process : {
     env: {
@@ -231,17 +231,19 @@ async function install_tox(tox_version: string = "") {
         exec.exec("tox --version");
         return;
     }
-    const hasPip = await exec.exec("which pip", [], ignoreFail);
+    const hasPipx = await exec.exec("which pipx", [], ignoreFail);
     const version = tox_version ? `==${tox_version}` : "";
-    if (hasPip == 0) {
-        core.info(`pip is available, install tox${version}`);
-        await exec.exec(`pip install tox${version}`);
-    } else {
-        core.info("Neither tox nor pip are available, install python3-pip via apt, then tox");
-        await apt_get("update -yqq");
-        await apt_get("install -yqq python3-pip");
-        await exec.exec(`sudo --preserve-env=http_proxy,https_proxy,no_proxy pip3 install tox${version}`);
+    if (hasPipx === 0) {
+        core.info(`pipx ins available, installing tox${version}`)
+        await exec.exec(`pipx install tox${version}`)
+        return;
     }
+    core.info("Neither tox nor pip are available, install pipx via apt then tox");
+    await apt_get("update -yqq");
+    await apt_get("install -yqq pipx");
+    await exec.exec("pipx ensurepath");
+    await exec.exec("sudo pipx ensurepath");
+    await exec.exec(`sudo --preserve-env=http_proxy,https_proxy,no_proxy pipx install tox${version}`);
 }
 
 

--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -234,11 +234,11 @@ async function install_tox(tox_version: string = "") {
     const hasPipx = await exec.exec("which pipx", [], ignoreFail);
     const version = tox_version ? `==${tox_version}` : "";
     if (hasPipx === 0) {
-        core.info(`pipx ins available, installing tox${version}`)
+        core.info(`pipx is available, installing tox${version}`)
         await exec.exec(`pipx install tox${version}`)
         return;
     }
-    core.info("Neither tox nor pip are available, install pipx via apt then tox");
+    core.info("Neither tox nor pipx are available, install pipx via apt then tox");
     await apt_get("update -yqq");
     await apt_get("install -yqq pipx");
     await exec.exec("pipx ensurepath");

--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -236,7 +236,6 @@ async function install_tox(tox_version: string = "") {
     const version = tox_version ? `==${tox_version}` : "";
     const pip_path = (await checkOutput("which", ["pip"], ignoreFail)).trim();
     const is_sys_pip = pip_path === SYSTEM_PIP_PATH;
-    core.info(`PIP PATH: ${pip_path} is sys pip: ${is_sys_pip}`)
     // Avoid installing on system managed Python which may break system dependencies.
     if (pip_path && !is_sys_pip) {
         core.info(`externally managed pip is available, installing tox${version}`)
@@ -249,7 +248,7 @@ async function install_tox(tox_version: string = "") {
         await exec.exec(`pipx install tox${version}`)
         return;
     }
-    core.info("Neither tox nor pipx are available, install pipx via apt then tox");
+    core.info("Neither pip, pipx nor tox are available, install pipx via apt then tox");
     await apt_get("update -yqq");
     await apt_get("install -yqq pipx");
     await exec.exec("pipx ensurepath");

--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -243,7 +243,7 @@ async function install_tox(tox_version: string = "") {
     await apt_get("install -yqq pipx");
     await exec.exec("pipx ensurepath");
     await exec.exec("sudo pipx ensurepath");
-    await exec.exec(`sudo --preserve-env=http_proxy,https_proxy,no_proxy pipx install tox${version}`);
+    await exec.exec(`pipx install tox${version}`);
 }
 
 


### PR DESCRIPTION
Install tox via pipx rather that pip.
On Noble images, any installations via pip will trigger a warning that requires `--break-system-packages`.

See: https://github.com/canonical/cbartz-runner-testing/actions/runs/12162756292/job/33920464738#step:3:64

Fixed test run:
https://github.com/canonical/cbartz-runner-testing/actions/runs/12174242889

Fixes:
https://github.com/charmed-kubernetes/actions-operator/issues/91