### PR TITLE
Pin websockets to 13.1 when running juju 2.9 tests

### DIFF
--- a/tests/constraints-2.9.txt
+++ b/tests/constraints-2.9.txt
@@ -1,2 +1,3 @@
 cython<3
-websockets==13.1
+websockets==7.0; python_version <= "3.8"
+websockets==13.1; python_version > "3.8"


### PR DESCRIPTION
### Overview
* websockets 1.14 is incompatibility with python-libjuju 2.9, but that package doesn't handle this dependency well so we are managing it here in our tests. 

### Details
* in python 3.8 and below, pin to 7.0
* for others, pin to 13.1