### PR TITLE
Fix delay in retryable execution

### DIFF
--- a/dist/bootstrap/index.js
+++ b/dist/bootstrap/index.js
@@ -29082,7 +29082,7 @@ async function microk8s_init(channel, addons, container_registry_url) {
     await retry_until_rc("microk8s kubectl auth can-i create pods");
     return true;
 }
-const _retryable_exec = (command, initial = 10, maxTry = 5) => {
+const _retryable_exec = (command, initial = 10, maxTry = 6) => {
     // returns an async method capable of running the prog with sudo
     const fn = async (cmd_arg, args, options) => {
         // Run a command with sudo yielding the awaited Promise result

--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -186,7 +186,7 @@ async function microk8s_init(channel, addons, container_registry_url:string) {
 }
 
 
-const _retryable_exec = (command: string, initial: number = 10, maxTry: number = 5) => {
+const _retryable_exec = (command: string, initial: number = 10, maxTry: number = 6) => {
     // returns an async method capable of running the prog with sudo
     const fn = async (cmd_arg:string, args?: string[], options?: exec.ExecOptions): Promise<number> => {
         // Run a command with sudo yielding the awaited Promise result


### PR DESCRIPTION
There's a bug in `ts-retry` that causes `lastDelay` in `DelayParameters` not to be populated.

https://github.com/franckLdx/ts-retry/issues/41

This causes the `actions-operator` to retry immediately instead of using backoff, which creates problems in some workflows related to Snap, for example: https://github.com/canonical/nginx-ingress-integrator-operator/actions/runs/21815422114/job/63059385120?pr=316

In this pull request, `currentTry` of `DelayParameters` is used to construct the backoff delay to bypass this problem. And the default `maxTry` is also increased to 6, as the original value of 5 results in 1 initial try and 4 retries, which seems to contradict the retry delays described in the comment.
