### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: woke
-        uses: canonical-web-and-design/inclusive-naming@main
+        uses: canonical-web-and-design/inclusive-naming@7aa0f7a606f182bd03a7adb28e0d710216101ca5 # main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-check
@@ -24,7 +24,7 @@ jobs:
       channel: ${{ steps.charmcraft.outputs.channel }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Load charmcraft channel
         id: charmcraft
         run: echo "channel=$(cat tests/.charmcraft-channel)" >> $GITHUB_OUTPUT
@@ -44,11 +44,11 @@ jobs:
           - ''
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python }}
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: ./
         with:
           provider: lxd
@@ -77,10 +77,10 @@ jobs:
           - '3/stable'
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install Python
         if: ${{ ! contains(fromJson('["ubuntu-22.04"]'), matrix.os) }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
       - uses: ./
@@ -116,10 +116,10 @@ jobs:
           - 1.27-strict/stable
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install Python
         if: ${{ ! contains(fromJson('["ubuntu-22.04"]'), matrix.os) }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
       - uses: ./
@@ -146,10 +146,10 @@ jobs:
           - latest/stable
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install Python
         if: ${{ ! contains(fromJson('["ubuntu-22.04"]'), matrix.os) }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
       - uses: ./
@@ -169,7 +169,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: ./
         with:
           provider: microk8s
@@ -186,7 +186,7 @@ jobs:
     name: Test vSphere environment
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: ./
         with:
           provider: vsphere
@@ -211,10 +211,10 @@ jobs:
           - ubuntu-24.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install Python
         if: ${{ ! contains(fromJson('["ubuntu-22.04"]'), matrix.os) }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
       - name: Setup k8s controller


### PR DESCRIPTION
Pin all GitHub Actions to their commit SHAs to improve supply chain security.

This prevents:
- Compromised tags from injecting malicious code
- Unexpected behavior from mutable references
- Supply chain attacks via action tag manipulation